### PR TITLE
Add Separate Folder Support for AAC Downloads

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@ cover-size: 5000x5000
 cover-format: jpg       #jpg png or original
 alac-save-folder: AM-DL downloads
 atmos-save-folder: AM-DL-Atmos downloads
+aac-save-folder: AM-DL-AAC downloads
 max-memory-limit: 256 # MB
 decrypt-m3u8-port: "127.0.0.1:10020"
 get-m3u8-port: "127.0.0.1:20020"

--- a/main.go
+++ b/main.go
@@ -645,6 +645,9 @@ func ripStation(albumId string, token string, storefront string, mediaUserToken 
 	if dl_atmos {
 		singerFolder = filepath.Join(Config.AtmosSaveFolder, forbiddenNames.ReplaceAllString(singerFoldername, "_"))
 	}
+	if dl_aac {
+		singerFolder = filepath.Join(Config.AacSaveFolder, forbiddenNames.ReplaceAllString(singerFoldername, "_"))
+	}
 	os.MkdirAll(singerFolder, os.ModePerm) // Create artist folder
 	station.SaveDir = singerFolder
 
@@ -897,6 +900,9 @@ func ripAlbum(albumId string, token string, storefront string, mediaUserToken st
 	singerFolder := filepath.Join(Config.AlacSaveFolder, forbiddenNames.ReplaceAllString(singerFoldername, "_"))
 	if dl_atmos {
 		singerFolder = filepath.Join(Config.AtmosSaveFolder, forbiddenNames.ReplaceAllString(singerFoldername, "_"))
+	}
+	if dl_aac {
+		singerFolder = filepath.Join(Config.AacSaveFolder, forbiddenNames.ReplaceAllString(singerFoldername, "_"))
 	}
 	os.MkdirAll(singerFolder, os.ModePerm) // Create artist folder
 	album.SaveDir = singerFolder
@@ -1181,6 +1187,9 @@ func ripPlaylist(playlistId string, token string, storefront string, mediaUserTo
 	singerFolder := filepath.Join(Config.AlacSaveFolder, forbiddenNames.ReplaceAllString(singerFoldername, "_"))
 	if dl_atmos {
 		singerFolder = filepath.Join(Config.AtmosSaveFolder, forbiddenNames.ReplaceAllString(singerFoldername, "_"))
+	}
+	if dl_aac {
+		singerFolder = filepath.Join(Config.AacSaveFolder, forbiddenNames.ReplaceAllString(singerFoldername, "_"))
 	}
 	os.MkdirAll(singerFolder, os.ModePerm) // Create artist folder
 	playlist.SaveDir = singerFolder

--- a/utils/structs/structs.go
+++ b/utils/structs/structs.go
@@ -16,6 +16,7 @@ type ConfigSet struct {
 	CoverFormat             string `yaml:"cover-format"`
 	AlacSaveFolder          string `yaml:"alac-save-folder"`
 	AtmosSaveFolder         string `yaml:"atmos-save-folder"`
+	AacSaveFolder           string `yaml:"aac-save-folder"`
 	AlbumFolderFormat       string `yaml:"album-folder-format"`
 	PlaylistFolderFormat    string `yaml:"playlist-folder-format"`
 	ArtistFolderFormat      string `yaml:"artist-folder-format"`


### PR DESCRIPTION
- AAC downloads are now saved in a dedicated folder:
  Introduced a separate folder path for AAC downloads, distinct from ALAC and ATMOS downloads, to improve organization and user experience.

- Configuration updated:
The config.yaml now includes an aac-save-folder option, allowing users to specify the destination for AAC files.
- Main downloader logic updated:
The Go downloader (main.go) now correctly routes AAC downloads to the specified AAC folder, ensuring files are not mixed with other formats.
- No impact on ALAC or ATMOS downloads:
Existing download logic for ALAC and ATMOS remains unchanged.
Benefits:

- Easier management and retrieval of AAC files.
- Prevents confusion between different audio quality downloads.
- Aligns with user requests for better file organization.
