### PR TITLE
Add AIFF conversion and bit-depth detection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,7 +53,7 @@ mv-max: 2160
 storefront: "enter your account storefront"
 # Conversion settings
 convert-after-download: false     # Enable post-download conversion (requires ffmpeg)
-convert-format: "flac"            # flac | mp3 | opus | wav | copy (no re-encode)
+convert-format: "flac"            # flac | mp3 | opus | wav | aiff | copy (no re-encode)
 convert-keep-original: false       # Keep original file after successful conversion
 convert-skip-if-source-matches: true  # If already in target format, skip
 ffmpeg-path: "ffmpeg"             # Override if ffmpeg is not in PATH
@@ -61,6 +61,6 @@ convert-extra-args: ""            # Additional raw args appended (advanced)
 convert-with-metadata: true      # If true, keep the same metadata in converted files
 # Conversion warnings and behavior
 convert-warn-lossy-to-lossless: true # If true, print a warning when converting a detected lossy source to a lossless container
-convert-skip-lossy-to-lossless: true # If true, skip converting detected lossy sources to lossless target formats (flac/wav)
+convert-skip-lossy-to-lossless: true # If true, skip converting detected lossy sources to lossless target formats (flac/wav/aiff)
 convert-check-bad-alac: false # If true, check and report if ALAC is damaged
 convert-delete-bad-alac: false # If true, delete if ALAC is damaged

--- a/main.go
+++ b/main.go
@@ -659,8 +659,39 @@ func isLossySource(ext string, codec string) bool {
 	return false
 }
 
+// CONVERSION FEATURE: Get bit depth of an audio file using ffprobe
+func getAudioBitDepth(ffmpegPath string, filePath string) (int, error) {
+	ffprobePath := strings.Replace(ffmpegPath, "ffmpeg", "ffprobe", 1)
+	if _, err := exec.LookPath(ffprobePath); err != nil {
+		return 16, fmt.Errorf("ffprobe not found: %w", err) // Default to 16
+	}
+
+	cmd := exec.Command(ffprobePath, "-v", "error", "-select_streams", "a:0", "-show_entries", "stream=bits_per_raw_sample", "-of", "default=noprint_wrappers=1:nokey=1", filePath)
+	out, err := cmd.Output()
+	if err != nil {
+		return 16, err
+	}
+
+	bitsStr := strings.TrimSpace(string(out))
+	if bitsStr == "" || bitsStr == "N/A" {
+		// ALAC and sometimes FLAC might not report bits_per_raw_sample directly in all versions,
+		// fallback to sample_fmt based depth if needed, but ALAC usually reports bits_per_raw_sample nicely.
+		return 16, nil
+	}
+
+	bits, err := strconv.Atoi(bitsStr)
+	if err != nil {
+		return 16, err
+	}
+
+	if bits > 0 {
+		return bits, nil
+	}
+	return 16, nil
+}
+
 // CONVERSION FEATURE: Build ffmpeg arguments for desired target.
-func buildFFmpegArgs(ffmpegPath, inPath, outPath, targetFmt, extraArgs string) ([]string, error) {
+func buildFFmpegArgs(ffmpegPath, inPath, outPath, targetFmt, extraArgs string, srcBitDepth int) ([]string, error) {
 	args := []string{"-y", "-i", inPath, "-loglevel", "error", "-map_metadata"}
 	if Config.ConvertWithMetadata {
 		args = append(args, "0")
@@ -677,7 +708,17 @@ func buildFFmpegArgs(ffmpegPath, inPath, outPath, targetFmt, extraArgs string) (
 		// Medium/high quality
 		args = append(args, "-c:a", "libopus", "-b:a", "192k", "-vbr", "on")
 	case "wav":
-		args = append(args, "-c:a", "pcm_s16le")
+		codec := "pcm_s16le" // default 16-bit
+		if srcBitDepth == 24 || srcBitDepth == 32 {
+			codec = "pcm_s24le"
+		}
+		args = append(args, "-c:a", codec)
+	case "aiff":
+		codec := "pcm_s16be" // default 16-bit
+		if srcBitDepth == 24 || srcBitDepth == 32 {
+			codec = "pcm_s24be"
+		}
+		args = append(args, "-c:a", codec, "-write_id3v2", "1")
 	case "copy":
 		// Just container copy (probably pointless for same container)
 		args = append(args, "-c", "copy")
@@ -724,7 +765,7 @@ func convertIfNeeded(track *task.Track) {
 	outPath := outBase + "." + targetFmt
 
 	// Handle lossy -> lossless cases: optionally skip or warn
-	if (targetFmt == "flac" || targetFmt == "wav") && isLossySource(ext, track.Codec) {
+	if (targetFmt == "flac" || targetFmt == "wav" || targetFmt == "aiff") && isLossySource(ext, track.Codec) {
 		if Config.ConvertSkipLossyToLossless {
 			fmt.Println("Skipping conversion: source appears lossy and target is lossless; configured to skip.")
 			return
@@ -739,7 +780,17 @@ func convertIfNeeded(track *task.Track) {
 		return
 	}
 
-	args, err := buildFFmpegArgs(Config.FFmpegPath, srcPath, outPath, targetFmt, Config.ConvertExtraArgs)
+	srcBitDepth := 16
+	if targetFmt == "aiff" || targetFmt == "wav" || targetFmt == "flac" {
+		depth, err := getAudioBitDepth(Config.FFmpegPath, srcPath)
+		if err != nil {
+			fmt.Printf("Warning: failed to detect source bit depth, defaulting to 16-bit. Error: %v\n", err)
+		} else {
+			srcBitDepth = depth
+		}
+	}
+
+	args, err := buildFFmpegArgs(Config.FFmpegPath, srcPath, outPath, targetFmt, Config.ConvertExtraArgs, srcBitDepth)
 	if err != nil {
 		fmt.Println("Conversion config error:", err)
 		return

--- a/utils/structs/structs.go
+++ b/utils/structs/structs.go
@@ -18,7 +18,7 @@ type ConfigSet struct {
 	AlacSaveFolder             string `yaml:"alac-save-folder"`
 	AtmosSaveFolder            string `yaml:"atmos-save-folder"`
 	AacSaveFolder              string `yaml:"aac-save-folder"`
-  MVSaveFolder               string `yaml:"mv-save-folder"`
+  	MVSaveFolder               string `yaml:"mv-save-folder"`
 	AlbumFolderFormat          string `yaml:"album-folder-format"`
 	PlaylistFolderFormat       string `yaml:"playlist-folder-format"`
 	ArtistFolderFormat         string `yaml:"artist-folder-format"`


### PR DESCRIPTION
Enable AIFF as a conversion target and detect source bit depth via ffprobe. Added getAudioBitDepth to probe bits_per_raw_sample (defaulting to 16 on error), extended buildFFmpegArgs to accept srcBitDepth and choose appropriate PCM codecs (pcm_s16le/pcm_s24le for WAV, pcm_s16be/pcm_s24be for AIFF) and include -write_id3v2 for AIFF. convertIfNeeded now treats AIFF as a lossless target (honors skip-on-lossy config) and queries source bit depth before building ffmpeg args. Updated config comments to list aiff and mention lossy->lossless handling for AIFF.