### PR TITLE
ALAC files fixing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 !main.go
 !README.md
 !utils/*
+!cmd/
+!cmd/**

--- a/cmd/alacfix/main.go
+++ b/cmd/alacfix/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"main/utils/alacfix"
+)
+
+func main() {
+	var inPlace bool
+	flag.BoolVar(&inPlace, "i", false, "modify file in place")
+	flag.BoolVar(&inPlace, "in-place", false, "modify file in place")
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  alacfix <input.m4a> <output.m4a>")
+		fmt.Fprintln(os.Stderr, "  alacfix -i <input.m4a>")
+	}
+	flag.Parse()
+
+	args := flag.Args()
+
+	var input, output string
+	switch {
+	case inPlace && len(args) == 1:
+		input = args[0]
+	case !inPlace && len(args) == 2:
+		input, output = args[0], args[1]
+	default:
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if err := alacfix.Run(input, output); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/alacfix/main.go
+++ b/cmd/alacfix/main.go
@@ -9,13 +9,19 @@ import (
 )
 
 func main() {
-	var inPlace bool
+	var inPlace, force bool
 	flag.BoolVar(&inPlace, "i", false, "modify file in place")
 	flag.BoolVar(&inPlace, "in-place", false, "modify file in place")
+	flag.BoolVar(&force, "f", false, "always write output even if no patches applied")
+	flag.BoolVar(&force, "force", false, "always write output even if no patches applied")
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage:")
-		fmt.Fprintln(os.Stderr, "  alacfix <input.m4a> <output.m4a>")
-		fmt.Fprintln(os.Stderr, "  alacfix -i <input.m4a>")
+		fmt.Fprintln(os.Stderr, "  alacfix [-f] <input.m4a> <output.m4a>")
+		fmt.Fprintln(os.Stderr, "  alacfix [-f] -i <input.m4a>")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Flags:")
+		fmt.Fprintln(os.Stderr, "  -i, --in-place   modify file in place")
+		fmt.Fprintln(os.Stderr, "  -f, --force      always write output even if no patches applied")
 	}
 	flag.Parse()
 
@@ -32,7 +38,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := alacfix.Run(input, output); err != nil {
+	if err := alacfix.Run(input, force, output); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -53,6 +53,7 @@ mv-max: 2160
 # if your account is from Japan, you must use jp.
 # if the storefront is different from your account, you will see a "failed to get lyrics" error in most of the songs. By default the storefront is set to US if not set.
 storefront: "enter your account storefront"
+alac-fix: false                   # Patch malformed ALAC packets
 # Conversion settings
 convert-after-download: false     # Enable post-download conversion (requires ffmpeg)
 convert-format: "flac"            # flac | mp3 | opus | wav | copy (no re-encode)

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"main/utils/alacfix"
 	"main/utils/ampapi"
 	"main/utils/lyrics"
 	"main/utils/runv2"
@@ -1040,6 +1041,14 @@ func ripTrack(track *task.Track, token string, mediaUserToken string) {
 		}
 	}
 	track.SavePath = trackPath
+
+	err = alacfix.Run(track.SavePath)
+	if err != nil {
+		fmt.Println("\u26A0 Failed to fix ALAC:", err)
+		counter.Unavailable++
+		return
+	}
+
 	err = writeMP4Tags(track, lrc)
 	if err != nil {
 		fmt.Println("\u26A0 Failed to write tags in media:", err)

--- a/main.go
+++ b/main.go
@@ -1043,7 +1043,7 @@ func ripTrack(track *task.Track, token string, mediaUserToken string) {
 	track.SavePath = trackPath
 
 	if Config.ALACFix {
-		err = alacfix.Run(track.SavePath)
+		err = alacfix.Run(track.SavePath, false)
 		if err != nil {
 			fmt.Println("\u26A0 Failed to fix ALAC:", err)
 			counter.Unavailable++
@@ -1791,8 +1791,8 @@ func ripPlaylist(playlistId string, token string, storefront string, mediaUserTo
 
 func writeMP4Tags(track *task.Track, lrc string) error {
 	t := &mp4tag.MP4Tags{
-		Title:      track.Resp.Attributes.Name,
-		Artist:     track.Resp.Attributes.ArtistName,
+		Title:  track.Resp.Attributes.Name,
+		Artist: track.Resp.Attributes.ArtistName,
 		Custom: map[string]string{
 			"PERFORMER":   track.Resp.Attributes.ArtistName,
 			"RELEASETIME": track.Resp.Attributes.ReleaseDate,
@@ -1800,12 +1800,12 @@ func writeMP4Tags(track *task.Track, lrc string) error {
 			"LABEL":       "",
 			"UPC":         "",
 		},
-		Composer:     track.Resp.Attributes.ComposerName,
-		CustomGenre:  track.Resp.Attributes.GenreNames[0],
-		Lyrics:       lrc,
-		TrackNumber:  int16(track.Resp.Attributes.TrackNumber),
-		DiscNumber:   int16(track.Resp.Attributes.DiscNumber),
-		Album:        track.Resp.Attributes.AlbumName,
+		Composer:    track.Resp.Attributes.ComposerName,
+		CustomGenre: track.Resp.Attributes.GenreNames[0],
+		Lyrics:      lrc,
+		TrackNumber: int16(track.Resp.Attributes.TrackNumber),
+		DiscNumber:  int16(track.Resp.Attributes.DiscNumber),
+		Album:       track.Resp.Attributes.AlbumName,
 	}
 
 	if Config.TagSortOrder {

--- a/main.go
+++ b/main.go
@@ -1042,11 +1042,13 @@ func ripTrack(track *task.Track, token string, mediaUserToken string) {
 	}
 	track.SavePath = trackPath
 
-	err = alacfix.Run(track.SavePath)
-	if err != nil {
-		fmt.Println("\u26A0 Failed to fix ALAC:", err)
-		counter.Unavailable++
-		return
+	if Config.ALACFix {
+		err = alacfix.Run(track.SavePath)
+		if err != nil {
+			fmt.Println("\u26A0 Failed to fix ALAC:", err)
+			counter.Unavailable++
+			return
+		}
 	}
 
 	err = writeMP4Tags(track, lrc)

--- a/utils/alacfix/alacfix.go
+++ b/utils/alacfix/alacfix.go
@@ -679,7 +679,7 @@ func patchInPlace(data []byte, off int64, size int, bodyEndBit int) bool {
 
 // ---------- main ------------------------------------------------------------
 
-func Run(path string, outPath ...string) error {
+func Run(path string, force bool, outPath ...string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
@@ -735,7 +735,7 @@ func Run(path string, outPath ...string) error {
 		}
 	}
 
-	if patched > 0 {
+	if patched > 0 || force {
 		if err := os.WriteFile(dst, data, 0644); err != nil {
 			return err
 		}

--- a/utils/alacfix/alacfix.go
+++ b/utils/alacfix/alacfix.go
@@ -1,0 +1,670 @@
+package alacfix
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// alacfix.go — Patch malformed ALAC packets in an .m4a/.mp4 file in place.
+//
+// Some ALAC encoders emit packets that are missing the TYPE_END (3-bit value 7)
+// terminator at the end of the bitstream. FFmpeg's decoder rejects them with
+// errors like "invalid element channel count" or "Syntax element 4 is not
+// implemented" because after the legitimate first element it tries to parse
+// the garbage tail as a new element header.
+//
+// This program walks the ISO BMFF container to find the audio track's ALAC
+// packets, parses each packet far enough to locate the end of its element
+// body, and — if the tail does not already start with TYPE_END — overwrites
+// the 3 bits there with 111 and zero-pads to the end of the packet. Packet
+// sizes do not change, so no container rewriting is required.
+
+// ---------- Bit reader ------------------------------------------------------
+
+type bitReader struct {
+	buf   []byte
+	pos   int // bit position from MSB of buf[0]
+	nbits int
+}
+
+func newBitReader(buf []byte) *bitReader {
+	return &bitReader{buf: buf, nbits: len(buf) * 8}
+}
+
+func (b *bitReader) left() int { return b.nbits - b.pos }
+
+func (b *bitReader) read(n int) (uint32, error) {
+	if n == 0 {
+		return 0, nil
+	}
+	if b.pos+n > b.nbits {
+		return 0, io_EOF
+	}
+	var v uint32
+	p := b.pos
+	for i := 0; i < n; i++ {
+		bit := uint32((b.buf[p>>3] >> (7 - uint(p&7))) & 1)
+		v = (v << 1) | bit
+		p++
+	}
+	b.pos = p
+	return v, nil
+}
+
+func (b *bitReader) show(n int) (uint32, error) {
+	save := b.pos
+	v, err := b.read(n)
+	b.pos = save
+	return v, err
+}
+
+func (b *bitReader) skip(n int) error {
+	if b.pos+n > b.nbits {
+		return io_EOF
+	}
+	b.pos += n
+	return nil
+}
+
+func (b *bitReader) readSigned(n int) (int32, error) {
+	v, err := b.read(n)
+	if err != nil {
+		return 0, err
+	}
+	if v&(1<<uint(n-1)) != 0 {
+		return int32(v) - int32(1<<uint(n)), nil
+	}
+	return int32(v), nil
+}
+
+func (b *bitReader) unary09() (uint32, error) {
+	cnt := uint32(0)
+	for cnt < 9 {
+		v, err := b.read(1)
+		if err != nil {
+			return 0, err
+		}
+		if v == 0 {
+			return cnt, nil
+		}
+		cnt++
+	}
+	return 9, nil
+}
+
+var io_EOF = errors.New("bit reader EOF")
+
+func avLog2(x uint32) int {
+	if x == 0 {
+		return 0
+	}
+	r := 0
+	for x > 1 {
+		x >>= 1
+		r++
+	}
+	return r
+}
+
+// ---------- ALAC element body scanner --------------------------------------
+// Mirrors libavcodec/alac.c: decode_scalar, rice_decompress, decode_element.
+
+type alacParams struct {
+	maxSamplesPerFrame uint32
+	sampleSize         uint8
+	riceHistoryMult    uint8
+	riceInitialHistory uint8
+	riceLimit          uint8
+	channels           uint8
+}
+
+func decodeScalar(br *bitReader, k int, bps int) (uint32, error) {
+	x, err := br.unary09()
+	if err != nil {
+		return 0, err
+	}
+	if x > 8 {
+		return br.read(bps)
+	}
+	if k != 1 {
+		extrabits, err := br.show(k)
+		if err != nil {
+			return 0, err
+		}
+		x = (x << uint(k)) - x
+		if extrabits > 1 {
+			x += extrabits - 1
+			if err := br.skip(k); err != nil {
+				return 0, err
+			}
+		} else {
+			if err := br.skip(k - 1); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return x, nil
+}
+
+func riceDecompress(br *bitReader, nbSamples int, bps int, rhmEff uint32, p *alacParams) error {
+	history := uint32(p.riceInitialHistory)
+	signMod := uint32(0)
+	limit := int(p.riceLimit)
+	cap := nbSamples*4 + 100
+	iters := 0
+	for i := 0; i < nbSamples; {
+		iters++
+		if iters > cap {
+			return errors.New("rice runaway")
+		}
+		if br.left() <= 0 {
+			return io_EOF
+		}
+		k := avLog2((history >> 9) + 3)
+		if k > limit {
+			k = limit
+		}
+		x, err := decodeScalar(br, k, bps)
+		if err != nil {
+			return err
+		}
+		x = x + signMod
+		signMod = 0
+		if x > 0xFFFF {
+			history = 0xFFFF
+		} else {
+			history = history + x*rhmEff - ((history * rhmEff) >> 9)
+		}
+		if history < 128 && (i+1) < nbSamples {
+			k2 := 7 - avLog2(history) + int((history+16)>>6)
+			if k2 > limit {
+				k2 = limit
+			}
+			blockSize, err := decodeScalar(br, k2, 16)
+			if err != nil {
+				return err
+			}
+			if blockSize > 0 {
+				if int(blockSize) >= nbSamples-i {
+					blockSize = uint32(nbSamples - i - 1)
+				}
+				i += int(blockSize)
+			}
+			if blockSize <= 0xFFFF {
+				signMod = 1
+			}
+			history = 0
+		}
+		i++
+	}
+	return nil
+}
+
+// scanOneElement consumes one element from br. Returns (channels_used,
+// is_end_tag, error). If an unsupported element tag is hit, returns an error.
+func scanOneElement(br *bitReader, p *alacParams) (int, bool, error) {
+	elem, err := br.read(3)
+	if err != nil {
+		return 0, false, err
+	}
+	if elem == 7 {
+		return 0, true, nil
+	}
+	if elem > 1 && elem != 3 {
+		return 0, false, fmt.Errorf("unsupported element tag %d", elem)
+	}
+	channels := 1
+	if elem == 1 {
+		channels = 2
+	}
+	if err := br.skip(4); err != nil {
+		return 0, false, err
+	}
+	if err := br.skip(12); err != nil {
+		return 0, false, err
+	}
+	hasSize, err := br.read(1)
+	if err != nil {
+		return 0, false, err
+	}
+	extraBitsRaw, err := br.read(2)
+	if err != nil {
+		return 0, false, err
+	}
+	extraBits := int(extraBitsRaw) << 3
+	bps := int(p.sampleSize) - extraBits + channels - 1
+	if bps > 32 || bps < 1 {
+		return 0, false, fmt.Errorf("bad bps %d", bps)
+	}
+	notCompressed, err := br.read(1)
+	if err != nil {
+		return 0, false, err
+	}
+	isCompressed := notCompressed == 0
+	var outputSamples uint32
+	if hasSize != 0 {
+		outputSamples, err = br.read(32)
+		if err != nil {
+			return 0, false, err
+		}
+	} else {
+		outputSamples = p.maxSamplesPerFrame
+	}
+	if outputSamples == 0 || outputSamples > p.maxSamplesPerFrame {
+		return 0, false, fmt.Errorf("bad output_samples %d", outputSamples)
+	}
+
+	if isCompressed {
+		if _, err := br.read(8); err != nil { // decorr_shift
+			return 0, false, err
+		}
+		decorrLeftWeight, err := br.read(8)
+		if err != nil {
+			return 0, false, err
+		}
+		// We don't bother validating decorr_shift>31 here — the FFmpeg check
+		// uses the *shift* value, but we already discarded it; for a scanner,
+		// what matters is bit position, not strict validation.
+		_ = decorrLeftWeight
+
+		rhms := make([]uint32, channels)
+		for c := 0; c < channels; c++ {
+			if _, err := br.read(4); err != nil { // pred_type
+				return 0, false, err
+			}
+			lpcQuant, err := br.read(4)
+			if err != nil {
+				return 0, false, err
+			}
+			rhm, err := br.read(3)
+			if err != nil {
+				return 0, false, err
+			}
+			lpcOrder, err := br.read(5)
+			if err != nil {
+				return 0, false, err
+			}
+			if lpcOrder >= p.maxSamplesPerFrame || lpcQuant == 0 {
+				return 0, false, fmt.Errorf("bad lpc")
+			}
+			for j := uint32(0); j < lpcOrder; j++ {
+				if _, err := br.readSigned(16); err != nil {
+					return 0, false, err
+				}
+			}
+			rhms[c] = rhm
+		}
+		if extraBits != 0 {
+			need := int(outputSamples) * channels * extraBits
+			if br.left() < need {
+				return 0, false, io_EOF
+			}
+			if err := br.skip(need); err != nil {
+				return 0, false, err
+			}
+		}
+		for c := 0; c < channels; c++ {
+			rhmEff := (rhms[c] * uint32(p.riceHistoryMult)) / 4
+			if err := riceDecompress(br, int(outputSamples), bps, rhmEff, p); err != nil {
+				return 0, false, err
+			}
+		}
+	} else {
+		need := int(outputSamples) * channels * int(p.sampleSize)
+		if br.left() < need {
+			return 0, false, io_EOF
+		}
+		if err := br.skip(need); err != nil {
+			return 0, false, err
+		}
+	}
+	return channels, false, nil
+}
+
+// findBodyEndBit returns the bit position right after the last non-END
+// element body. -1 means parse failure.
+func findBodyEndBit(packet []byte, p *alacParams) int {
+	br := newBitReader(packet)
+	chUsed := 0
+	lastEnd := -1
+	for br.left() >= 3 {
+		nCh, isEnd, err := scanOneElement(br, p)
+		if err != nil {
+			return -1
+		}
+		if isEnd {
+			return br.pos
+		}
+		lastEnd = br.pos
+		chUsed += nCh
+		if chUsed >= int(p.channels) {
+			return lastEnd
+		}
+	}
+	return lastEnd
+}
+
+// ---------- ISO BMFF walker -------------------------------------------------
+
+type atom struct {
+	typ     string
+	bodyOff int
+	endOff  int // exclusive
+}
+
+func walkAtoms(buf []byte, start, end int, recurse map[string]bool, out *[]atom) {
+	p := start
+	for p < end-8 {
+		size := int(binary.BigEndian.Uint32(buf[p : p+4]))
+		typ := string(buf[p+4 : p+8])
+		hdr := 8
+		if size == 1 {
+			if p+16 > end {
+				return
+			}
+			size = int(binary.BigEndian.Uint64(buf[p+8 : p+16]))
+			hdr = 16
+		} else if size == 0 {
+			size = end - p
+		}
+		if size < hdr || p+size > end {
+			return
+		}
+		body := p + hdr
+		atomEnd := p + size
+		*out = append(*out, atom{typ: typ, bodyOff: body, endOff: atomEnd})
+		if recurse[typ] {
+			off := body
+			if typ == "meta" {
+				off += 4 // version+flags
+			}
+			walkAtoms(buf, off, atomEnd, recurse, out)
+		}
+		p += size
+	}
+}
+
+var bmffContainers = map[string]bool{
+	"moov": true, "trak": true, "mdia": true, "minf": true,
+	"stbl": true, "dinf": true, "udta": true, "ilst": true,
+	"meta": true, "edts": true,
+}
+
+// ---------- Track metadata extraction --------------------------------------
+
+type packetLoc struct {
+	offset int64
+	size   int
+}
+
+func parseAlacMagicCookie(c []byte) (alacParams, error) {
+	var p alacParams
+	if len(c) != 36 || string(c[4:8]) != "alac" {
+		return p, errors.New("not an ALAC magic cookie")
+	}
+	// size(4) | 'alac'(4) | ver(4) | maxFrames(4) | compat(1) | sampleSize(1)
+	// | histMult(1) | initHist(1) | riceLim(1) | channels(1) | maxRun(2)
+	// | maxFrameSize(4) | avgBitrate(4) | sampleRate(4)
+	p.maxSamplesPerFrame = binary.BigEndian.Uint32(c[12:16])
+	p.sampleSize = c[17]
+	p.riceHistoryMult = c[18]
+	p.riceInitialHistory = c[19]
+	p.riceLimit = c[20]
+	p.channels = c[21]
+	return p, nil
+}
+
+func findAudioTrack(data []byte) (alacParams, []packetLoc, error) {
+	var top []atom
+	walkAtoms(data, 0, len(data), bmffContainers, &top)
+
+	var audioBody, audioEnd int
+	found := false
+	for _, a := range top {
+		if a.typ != "trak" {
+			continue
+		}
+		// Search inside this trak for "alac" tag.
+		blob := data[a.bodyOff:a.endOff]
+		if containsBytes(blob, []byte("alac")) {
+			audioBody = a.bodyOff
+			audioEnd = a.endOff
+			found = true
+			break
+		}
+	}
+	if !found {
+		return alacParams{}, nil, errors.New("no audio track found")
+	}
+
+	// Walk inside the audio trak.
+	var sub []atom
+	walkAtoms(data, audioBody, audioEnd, bmffContainers, &sub)
+
+	var stsz, stco, stsc *atom
+	is64 := false
+	for i := range sub {
+		switch sub[i].typ {
+		case "stsz":
+			stsz = &sub[i]
+		case "stco":
+			stco = &sub[i]
+		case "co64":
+			stco = &sub[i]
+			is64 = true
+		case "stsc":
+			stsc = &sub[i]
+		}
+	}
+	if stsz == nil || stco == nil || stsc == nil {
+		return alacParams{}, nil, errors.New("missing stsz/stco/stsc")
+	}
+
+	// Find magic cookie (36-byte block whose size==36 and tag=='alac').
+	var magic []byte
+	for i := audioBody; i+36 <= audioEnd; i++ {
+		if string(data[i+4:i+8]) == "alac" &&
+			binary.BigEndian.Uint32(data[i:i+4]) == 36 {
+			magic = data[i : i+36]
+			break
+		}
+	}
+	if magic == nil {
+		return alacParams{}, nil, errors.New("ALAC magic cookie not found")
+	}
+	params, err := parseAlacMagicCookie(magic)
+	if err != nil {
+		return alacParams{}, nil, err
+	}
+
+	// stsz: version+flags(4) | sample_size(4) | sample_count(4) | entries
+	b := stsz.bodyOff
+	defaultSize := binary.BigEndian.Uint32(data[b+4 : b+8])
+	count := int(binary.BigEndian.Uint32(data[b+8 : b+12]))
+	sizes := make([]uint32, count)
+	if defaultSize == 0 {
+		for i := 0; i < count; i++ {
+			sizes[i] = binary.BigEndian.Uint32(data[b+12+4*i : b+16+4*i])
+		}
+	} else {
+		for i := 0; i < count; i++ {
+			sizes[i] = defaultSize
+		}
+	}
+
+	// stco / co64
+	b = stco.bodyOff
+	ent := int(binary.BigEndian.Uint32(data[b+4 : b+8]))
+	chunkOff := make([]int64, ent)
+	p := b + 8
+	if is64 {
+		for i := 0; i < ent; i++ {
+			chunkOff[i] = int64(binary.BigEndian.Uint64(data[p : p+8]))
+			p += 8
+		}
+	} else {
+		for i := 0; i < ent; i++ {
+			chunkOff[i] = int64(binary.BigEndian.Uint32(data[p : p+4]))
+			p += 4
+		}
+	}
+
+	// stsc
+	b = stsc.bodyOff
+	ent = int(binary.BigEndian.Uint32(data[b+4 : b+8]))
+	type stscRun struct{ firstChunk, samplesPerChunk uint32 }
+	runs := make([]stscRun, ent)
+	p = b + 8
+	for i := 0; i < ent; i++ {
+		runs[i] = stscRun{
+			firstChunk:      binary.BigEndian.Uint32(data[p : p+4]),
+			samplesPerChunk: binary.BigEndian.Uint32(data[p+4 : p+8]),
+		}
+		p += 12
+	}
+
+	samplesPerChunk := make([]uint32, len(chunkOff))
+	for i, r := range runs {
+		var nextFC uint32
+		if i+1 < len(runs) {
+			nextFC = runs[i+1].firstChunk
+		} else {
+			nextFC = uint32(len(chunkOff)) + 1
+		}
+		for c := r.firstChunk; c < nextFC && int(c-1) < len(chunkOff); c++ {
+			samplesPerChunk[c-1] = r.samplesPerChunk
+		}
+	}
+	for i := range samplesPerChunk {
+		if samplesPerChunk[i] == 0 {
+			samplesPerChunk[i] = runs[len(runs)-1].samplesPerChunk
+		}
+	}
+
+	locs := make([]packetLoc, 0, len(sizes))
+	sampleIdx := 0
+	for c, choff := range chunkOff {
+		cur := choff
+		spc := int(samplesPerChunk[c])
+		for k := 0; k < spc && sampleIdx < len(sizes); k++ {
+			sz := int(sizes[sampleIdx])
+			locs = append(locs, packetLoc{offset: cur, size: sz})
+			cur += int64(sz)
+			sampleIdx++
+		}
+		if sampleIdx >= len(sizes) {
+			break
+		}
+	}
+	return params, locs, nil
+}
+
+func containsBytes(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := 0; j < len(needle); j++ {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------- Patcher ---------------------------------------------------------
+
+func patchInPlace(data []byte, off int64, size int, bodyEndBit int) bool {
+	totalBits := size * 8
+	if bodyEndBit < 0 || bodyEndBit+3 > totalBits {
+		return false
+	}
+	// Set 3 tag bits to 1,1,1.
+	for i := 0; i < 3; i++ {
+		bp := bodyEndBit + i
+		bi := off + int64(bp>>3)
+		mask := byte(1 << uint(7-(bp&7)))
+		data[bi] |= mask
+	}
+	// Zero everything from bodyEndBit+3 to end of packet.
+	padStart := bodyEndBit + 3
+	bi := off + int64(padStart>>3)
+	bitInByte := padStart & 7
+	if bitInByte != 0 {
+		keep := byte(0xFF<<uint(8-bitInByte)) & 0xFF
+		data[bi] &= keep
+		bi++
+	}
+	endByte := off + int64(size)
+	for j := bi; j < endByte; j++ {
+		data[j] = 0
+	}
+	return true
+}
+
+// ---------- main ------------------------------------------------------------
+
+func Run(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	params, locs, err := findAudioTrack(data)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Found %d ALAC packets. max_samples_per_frame=%d sample_size=%d channels=%d\n",
+		len(locs), params.maxSamplesPerFrame, params.sampleSize, params.channels)
+
+	patched := 0
+	type bad struct {
+		idx        int
+		off        int64
+		size       int
+		bodyEndBit int
+	}
+	var report []bad
+
+	for idx, loc := range locs {
+		pkt := data[loc.offset : loc.offset+int64(loc.size)]
+		bodyEnd := findBodyEndBit(pkt, &params)
+		if bodyEnd < 0 {
+			continue
+		}
+		if bodyEnd == loc.size*8 {
+			continue
+		}
+		// Already terminated by a TYPE_END?
+		br := newBitReader(pkt)
+		_ = br.skip(bodyEnd)
+		if br.left() >= 3 {
+			tag, _ := br.show(3)
+			if tag == 7 {
+				continue
+			}
+		}
+		if patchInPlace(data, loc.offset, loc.size, bodyEnd) {
+			patched++
+			report = append(report, bad{idx, loc.offset, loc.size, bodyEnd})
+		}
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return err
+	}
+
+	fmt.Printf("Patched %d packet(s).\n", patched)
+	for _, r := range report {
+		fmt.Printf("  packet #%d  file_offset=0x%x  size=%d  body_ends_at_bit=%d  tail_overwritten=[%d..%d)\n",
+			r.idx, r.off, r.size, r.bodyEndBit, r.bodyEndBit, r.size*8)
+	}
+	return nil
+}

--- a/utils/alacfix/alacfix.go
+++ b/utils/alacfix/alacfix.go
@@ -679,10 +679,14 @@ func patchInPlace(data []byte, off int64, size int, bodyEndBit int) bool {
 
 // ---------- main ------------------------------------------------------------
 
-func Run(path string) error {
+func Run(path string, outPath ...string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
+	}
+	dst := path
+	if len(outPath) > 0 && outPath[0] != "" {
+		dst = outPath[0]
 	}
 	tracks, err := findAlacTracks(data)
 	if err != nil {
@@ -732,7 +736,7 @@ func Run(path string) error {
 	}
 
 	if patched > 0 {
-		if err := os.WriteFile(path, data, 0644); err != nil {
+		if err := os.WriteFile(dst, data, 0644); err != nil {
 			return err
 		}
 		fmt.Printf("Patched %d packet(s).\n", patched)

--- a/utils/alacfix/alacfix.go
+++ b/utils/alacfix/alacfix.go
@@ -416,30 +416,35 @@ func parseAlacMagicCookie(c []byte) (alacParams, error) {
 	return p, nil
 }
 
-func findAudioTrack(data []byte) (alacParams, []packetLoc, error) {
+type trackData struct {
+	params alacParams
+	locs   []packetLoc
+}
+
+func findAudioTracks(data []byte) ([]trackData, error) {
 	var top []atom
 	walkAtoms(data, 0, len(data), bmffContainers, &top)
 
-	var audioBody, audioEnd int
-	found := false
+	var tracks []trackData
 	for _, a := range top {
 		if a.typ != "trak" {
 			continue
 		}
-		// Search inside this trak for "alac" tag.
 		blob := data[a.bodyOff:a.endOff]
-		if containsBytes(blob, []byte("alac")) {
-			audioBody = a.bodyOff
-			audioEnd = a.endOff
-			found = true
-			break
+		if !containsBytes(blob, []byte("alac")) {
+			continue
 		}
-	}
-	if !found {
-		return alacParams{}, nil, errors.New("no audio track found")
-	}
 
-	// Walk inside the audio trak.
+		td, err := parseAlacTrack(data, a.bodyOff, a.endOff)
+		if err != nil {
+			return nil, err
+		}
+		tracks = append(tracks, td)
+	}
+	return tracks, nil
+}
+
+func parseAlacTrack(data []byte, audioBody, audioEnd int) (trackData, error) {
 	var sub []atom
 	walkAtoms(data, audioBody, audioEnd, bmffContainers, &sub)
 
@@ -459,7 +464,7 @@ func findAudioTrack(data []byte) (alacParams, []packetLoc, error) {
 		}
 	}
 	if stsz == nil || stco == nil || stsc == nil {
-		return alacParams{}, nil, errors.New("missing stsz/stco/stsc")
+		return trackData{}, errors.New("missing stsz/stco/stsc")
 	}
 
 	// Find magic cookie (36-byte block whose size==36 and tag=='alac').
@@ -472,11 +477,11 @@ func findAudioTrack(data []byte) (alacParams, []packetLoc, error) {
 		}
 	}
 	if magic == nil {
-		return alacParams{}, nil, errors.New("ALAC magic cookie not found")
+		return trackData{}, errors.New("ALAC magic cookie not found")
 	}
 	params, err := parseAlacMagicCookie(magic)
 	if err != nil {
-		return alacParams{}, nil, err
+		return trackData{}, err
 	}
 
 	// stsz: version+flags(4) | sample_size(4) | sample_count(4) | entries
@@ -558,7 +563,7 @@ func findAudioTrack(data []byte) (alacParams, []packetLoc, error) {
 			break
 		}
 	}
-	return params, locs, nil
+	return trackData{params: params, locs: locs}, nil
 }
 
 func containsBytes(haystack, needle []byte) bool {
@@ -617,54 +622,63 @@ func Run(path string) error {
 	if err != nil {
 		return err
 	}
-	params, locs, err := findAudioTrack(data)
+	tracks, err := findAudioTracks(data)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Found %d ALAC packets. max_samples_per_frame=%d sample_size=%d channels=%d\n",
-		len(locs), params.maxSamplesPerFrame, params.sampleSize, params.channels)
+	if len(tracks) == 0 {
+		return nil
+	}
 
-	patched := 0
 	type bad struct {
+		trackIdx   int
 		idx        int
 		off        int64
 		size       int
 		bodyEndBit int
 	}
+
+	patched := 0
 	var report []bad
 
-	for idx, loc := range locs {
-		pkt := data[loc.offset : loc.offset+int64(loc.size)]
-		bodyEnd := findBodyEndBit(pkt, &params)
-		if bodyEnd < 0 {
-			continue
-		}
-		if bodyEnd == loc.size*8 {
-			continue
-		}
-		// Already terminated by a TYPE_END?
-		br := newBitReader(pkt)
-		_ = br.skip(bodyEnd)
-		if br.left() >= 3 {
-			tag, _ := br.show(3)
-			if tag == 7 {
+	for ti, td := range tracks {
+		params := td.params
+		fmt.Printf("Track %d: %d ALAC packets, max_samples_per_frame=%d sample_size=%d channels=%d\n",
+			ti, len(td.locs), params.maxSamplesPerFrame, params.sampleSize, params.channels)
+
+		for idx, loc := range td.locs {
+			pkt := data[loc.offset : loc.offset+int64(loc.size)]
+			bodyEnd := findBodyEndBit(pkt, &params)
+			if bodyEnd < 0 {
 				continue
 			}
-		}
-		if patchInPlace(data, loc.offset, loc.size, bodyEnd) {
-			patched++
-			report = append(report, bad{idx, loc.offset, loc.size, bodyEnd})
+			if bodyEnd == loc.size*8 {
+				continue
+			}
+			br := newBitReader(pkt)
+			_ = br.skip(bodyEnd)
+			if br.left() >= 3 {
+				tag, _ := br.show(3)
+				if tag == 7 {
+					continue
+				}
+			}
+			if patchInPlace(data, loc.offset, loc.size, bodyEnd) {
+				patched++
+				report = append(report, bad{ti, idx, loc.offset, loc.size, bodyEnd})
+			}
 		}
 	}
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
-		return err
-	}
-
-	fmt.Printf("Patched %d packet(s).\n", patched)
-	for _, r := range report {
-		fmt.Printf("  packet #%d  file_offset=0x%x  size=%d  body_ends_at_bit=%d  tail_overwritten=[%d..%d)\n",
-			r.idx, r.off, r.size, r.bodyEndBit, r.bodyEndBit, r.size*8)
+	if patched > 0 {
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			return err
+		}
+		fmt.Printf("Patched %d packet(s).\n", patched)
+		for _, r := range report {
+			fmt.Printf("  track #%d packet #%d  file_offset=0x%x  size=%d  body_ends_at_bit=%d  tail_overwritten=[%d..%d)\n",
+				r.trackIdx, r.idx, r.off, r.size, r.bodyEndBit, r.bodyEndBit, r.size*8)
+		}
 	}
 	return nil
 }

--- a/utils/alacfix/alacfix.go
+++ b/utils/alacfix/alacfix.go
@@ -15,11 +15,14 @@ import (
 // implemented" because after the legitimate first element it tries to parse
 // the garbage tail as a new element header.
 //
-// This program walks the ISO BMFF container to find the audio track's ALAC
-// packets, parses each packet far enough to locate the end of its element
-// body, and — if the tail does not already start with TYPE_END — overwrites
-// the 3 bits there with 111 and zero-pads to the end of the packet. Packet
-// sizes do not change, so no container rewriting is required.
+// This file walks the ISO BMFF container, locates every audio track that
+// uses the ALAC codec (by checking the format code in stsd's sample entry,
+// not by string matching), parses each packet far enough to find where the
+// element body ends, and — if the tail does not already start with TYPE_END —
+// overwrites the 3 bits there with 111 and zero-pads to the end of the
+// packet. Packet sizes do not change, so the container itself is not rewritten.
+//
+// Tracks that use any other codec (AAC, FLAC, etc.) are silently skipped.
 
 // ---------- Bit reader ------------------------------------------------------
 
@@ -28,6 +31,8 @@ type bitReader struct {
 	pos   int // bit position from MSB of buf[0]
 	nbits int
 }
+
+var errEOF = errors.New("bit reader EOF")
 
 func newBitReader(buf []byte) *bitReader {
 	return &bitReader{buf: buf, nbits: len(buf) * 8}
@@ -40,13 +45,12 @@ func (b *bitReader) read(n int) (uint32, error) {
 		return 0, nil
 	}
 	if b.pos+n > b.nbits {
-		return 0, io_EOF
+		return 0, errEOF
 	}
 	var v uint32
 	p := b.pos
 	for i := 0; i < n; i++ {
-		bit := uint32((b.buf[p>>3] >> (7 - uint(p&7))) & 1)
-		v = (v << 1) | bit
+		v = (v << 1) | uint32((b.buf[p>>3]>>(7-uint(p&7)))&1)
 		p++
 	}
 	b.pos = p
@@ -62,7 +66,7 @@ func (b *bitReader) show(n int) (uint32, error) {
 
 func (b *bitReader) skip(n int) error {
 	if b.pos+n > b.nbits {
-		return io_EOF
+		return errEOF
 	}
 	b.pos += n
 	return nil
@@ -93,8 +97,6 @@ func (b *bitReader) unary09() (uint32, error) {
 	}
 	return 9, nil
 }
-
-var io_EOF = errors.New("bit reader EOF")
 
 func avLog2(x uint32) int {
 	if x == 0 {
@@ -160,7 +162,7 @@ func riceDecompress(br *bitReader, nbSamples int, bps int, rhmEff uint32, p *ala
 			return errors.New("rice runaway")
 		}
 		if br.left() <= 0 {
-			return io_EOF
+			return errEOF
 		}
 		k := avLog2((history >> 9) + 3)
 		if k > limit {
@@ -260,15 +262,9 @@ func scanOneElement(br *bitReader, p *alacParams) (int, bool, error) {
 		if _, err := br.read(8); err != nil { // decorr_shift
 			return 0, false, err
 		}
-		decorrLeftWeight, err := br.read(8)
-		if err != nil {
+		if _, err := br.read(8); err != nil { // decorr_left_weight
 			return 0, false, err
 		}
-		// We don't bother validating decorr_shift>31 here — the FFmpeg check
-		// uses the *shift* value, but we already discarded it; for a scanner,
-		// what matters is bit position, not strict validation.
-		_ = decorrLeftWeight
-
 		rhms := make([]uint32, channels)
 		for c := 0; c < channels; c++ {
 			if _, err := br.read(4); err != nil { // pred_type
@@ -299,7 +295,7 @@ func scanOneElement(br *bitReader, p *alacParams) (int, bool, error) {
 		if extraBits != 0 {
 			need := int(outputSamples) * channels * extraBits
 			if br.left() < need {
-				return 0, false, io_EOF
+				return 0, false, errEOF
 			}
 			if err := br.skip(need); err != nil {
 				return 0, false, err
@@ -314,7 +310,7 @@ func scanOneElement(br *bitReader, p *alacParams) (int, bool, error) {
 	} else {
 		need := int(outputSamples) * channels * int(p.sampleSize)
 		if br.left() < need {
-			return 0, false, io_EOF
+			return 0, false, errEOF
 		}
 		if err := br.skip(need); err != nil {
 			return 0, false, err
@@ -350,19 +346,21 @@ func findBodyEndBit(packet []byte, p *alacParams) int {
 
 type atom struct {
 	typ     string
+	hdrOff  int
 	bodyOff int
-	endOff  int // exclusive
+	endOff  int
 }
 
-func walkAtoms(buf []byte, start, end int, recurse map[string]bool, out *[]atom) {
+// findChild returns the first direct child atom of the given type within [start, end).
+func findChild(buf []byte, start, end int, typ string) (atom, bool) {
 	p := start
 	for p < end-8 {
 		size := int(binary.BigEndian.Uint32(buf[p : p+4]))
-		typ := string(buf[p+4 : p+8])
+		atomType := string(buf[p+4 : p+8])
 		hdr := 8
 		if size == 1 {
 			if p+16 > end {
-				return
+				return atom{}, false
 			}
 			size = int(binary.BigEndian.Uint64(buf[p+8 : p+16]))
 			hdr = 16
@@ -370,26 +368,42 @@ func walkAtoms(buf []byte, start, end int, recurse map[string]bool, out *[]atom)
 			size = end - p
 		}
 		if size < hdr || p+size > end {
-			return
+			return atom{}, false
 		}
-		body := p + hdr
-		atomEnd := p + size
-		*out = append(*out, atom{typ: typ, bodyOff: body, endOff: atomEnd})
-		if recurse[typ] {
-			off := body
-			if typ == "meta" {
-				off += 4 // version+flags
-			}
-			walkAtoms(buf, off, atomEnd, recurse, out)
+		if atomType == typ {
+			return atom{typ: atomType, hdrOff: p, bodyOff: p + hdr, endOff: p + size}, true
 		}
 		p += size
 	}
+	return atom{}, false
 }
 
-var bmffContainers = map[string]bool{
-	"moov": true, "trak": true, "mdia": true, "minf": true,
-	"stbl": true, "dinf": true, "udta": true, "ilst": true,
-	"meta": true, "edts": true,
+// findAllChildren returns every direct child of the given type within [start, end).
+func findAllChildren(buf []byte, start, end int, typ string) []atom {
+	var out []atom
+	p := start
+	for p < end-8 {
+		size := int(binary.BigEndian.Uint32(buf[p : p+4]))
+		atomType := string(buf[p+4 : p+8])
+		hdr := 8
+		if size == 1 {
+			if p+16 > end {
+				return out
+			}
+			size = int(binary.BigEndian.Uint64(buf[p+8 : p+16]))
+			hdr = 16
+		} else if size == 0 {
+			size = end - p
+		}
+		if size < hdr || p+size > end {
+			return out
+		}
+		if atomType == typ {
+			out = append(out, atom{typ: atomType, hdrOff: p, bodyOff: p + hdr, endOff: p + size})
+		}
+		p += size
+	}
+	return out
 }
 
 // ---------- Track metadata extraction --------------------------------------
@@ -399,92 +413,71 @@ type packetLoc struct {
 	size   int
 }
 
+type trackData struct {
+	trackID uint32
+	params  alacParams
+	locs    []packetLoc
+}
+
+// parseAlacMagicCookie parses the ALAC specific box payload (without atom header).
+// Layout: version_flags(4) | maxFrames(4) | compat(1) | sampleSize(1)
+//
+//	| histMult(1) | initHist(1) | riceLim(1) | channels(1) | ...
 func parseAlacMagicCookie(c []byte) (alacParams, error) {
 	var p alacParams
-	if len(c) != 36 || string(c[4:8]) != "alac" {
-		return p, errors.New("not an ALAC magic cookie")
+	if len(c) < 24 {
+		return p, errors.New("ALAC config too short")
 	}
-	// size(4) | 'alac'(4) | ver(4) | maxFrames(4) | compat(1) | sampleSize(1)
-	// | histMult(1) | initHist(1) | riceLim(1) | channels(1) | maxRun(2)
-	// | maxFrameSize(4) | avgBitrate(4) | sampleRate(4)
-	p.maxSamplesPerFrame = binary.BigEndian.Uint32(c[12:16])
-	p.sampleSize = c[17]
-	p.riceHistoryMult = c[18]
-	p.riceInitialHistory = c[19]
-	p.riceLimit = c[20]
-	p.channels = c[21]
+	p.maxSamplesPerFrame = binary.BigEndian.Uint32(c[4:8])
+	p.sampleSize = c[9]
+	p.riceHistoryMult = c[10]
+	p.riceInitialHistory = c[11]
+	p.riceLimit = c[12]
+	p.channels = c[13]
 	return p, nil
 }
 
-type trackData struct {
-	params alacParams
-	locs   []packetLoc
-}
-
-func findAudioTracks(data []byte) ([]trackData, error) {
-	var top []atom
-	walkAtoms(data, 0, len(data), bmffContainers, &top)
-
-	var tracks []trackData
-	for _, a := range top {
-		if a.typ != "trak" {
-			continue
+// extractAlacConfig reads the ALAC magic cookie from inside an `alac` sample
+// entry (handles both direct and 'wave'-wrapped layouts).
+func extractAlacConfig(data []byte, sampleEntry atom) (alacParams, error) {
+	// Sample entry has a fixed 28-byte audio header before any child atoms.
+	childStart := sampleEntry.bodyOff + 28
+	if cfg, ok := findChild(data, childStart, sampleEntry.endOff, "alac"); ok {
+		if cfg.endOff-cfg.bodyOff < 28 {
+			return alacParams{}, errors.New("alac config atom too small")
 		}
-		blob := data[a.bodyOff:a.endOff]
-		if !containsBytes(blob, []byte("alac")) {
-			continue
-		}
-
-		td, err := parseAlacTrack(data, a.bodyOff, a.endOff)
-		if err != nil {
-			return nil, err
-		}
-		tracks = append(tracks, td)
+		return parseAlacMagicCookie(data[cfg.bodyOff : cfg.bodyOff+28])
 	}
-	return tracks, nil
+	if wave, ok := findChild(data, childStart, sampleEntry.endOff, "wave"); ok {
+		if cfg, ok := findChild(data, wave.bodyOff, wave.endOff, "alac"); ok {
+			if cfg.endOff-cfg.bodyOff < 28 {
+				return alacParams{}, errors.New("alac config atom too small")
+			}
+			return parseAlacMagicCookie(data[cfg.bodyOff : cfg.bodyOff+28])
+		}
+	}
+	return alacParams{}, errors.New("no ALAC config inside sample entry")
 }
 
-func parseAlacTrack(data []byte, audioBody, audioEnd int) (trackData, error) {
-	var sub []atom
-	walkAtoms(data, audioBody, audioEnd, bmffContainers, &sub)
-
-	var stsz, stco, stsc *atom
+func readPacketLocations(data []byte, stbl atom) ([]packetLoc, error) {
+	stsz, ok := findChild(data, stbl.bodyOff, stbl.endOff, "stsz")
+	if !ok {
+		return nil, errors.New("stsz missing")
+	}
+	stsc, ok := findChild(data, stbl.bodyOff, stbl.endOff, "stsc")
+	if !ok {
+		return nil, errors.New("stsc missing")
+	}
+	stco, ok := findChild(data, stbl.bodyOff, stbl.endOff, "stco")
 	is64 := false
-	for i := range sub {
-		switch sub[i].typ {
-		case "stsz":
-			stsz = &sub[i]
-		case "stco":
-			stco = &sub[i]
-		case "co64":
-			stco = &sub[i]
-			is64 = true
-		case "stsc":
-			stsc = &sub[i]
+	if !ok {
+		stco, ok = findChild(data, stbl.bodyOff, stbl.endOff, "co64")
+		if !ok {
+			return nil, errors.New("stco/co64 missing")
 		}
-	}
-	if stsz == nil || stco == nil || stsc == nil {
-		return trackData{}, errors.New("missing stsz/stco/stsc")
+		is64 = true
 	}
 
-	// Find magic cookie (36-byte block whose size==36 and tag=='alac').
-	var magic []byte
-	for i := audioBody; i+36 <= audioEnd; i++ {
-		if string(data[i+4:i+8]) == "alac" &&
-			binary.BigEndian.Uint32(data[i:i+4]) == 36 {
-			magic = data[i : i+36]
-			break
-		}
-	}
-	if magic == nil {
-		return trackData{}, errors.New("ALAC magic cookie not found")
-	}
-	params, err := parseAlacMagicCookie(magic)
-	if err != nil {
-		return trackData{}, err
-	}
-
-	// stsz: version+flags(4) | sample_size(4) | sample_count(4) | entries
 	b := stsz.bodyOff
 	defaultSize := binary.BigEndian.Uint32(data[b+4 : b+8])
 	count := int(binary.BigEndian.Uint32(data[b+8 : b+12]))
@@ -499,7 +492,6 @@ func parseAlacTrack(data []byte, audioBody, audioEnd int) (trackData, error) {
 		}
 	}
 
-	// stco / co64
 	b = stco.bodyOff
 	ent := int(binary.BigEndian.Uint32(data[b+4 : b+8]))
 	chunkOff := make([]int64, ent)
@@ -516,7 +508,6 @@ func parseAlacTrack(data []byte, audioBody, audioEnd int) (trackData, error) {
 		}
 	}
 
-	// stsc
 	b = stsc.bodyOff
 	ent = int(binary.BigEndian.Uint32(data[b+4 : b+8]))
 	type stscRun struct{ firstChunk, samplesPerChunk uint32 }
@@ -542,9 +533,11 @@ func parseAlacTrack(data []byte, audioBody, audioEnd int) (trackData, error) {
 			samplesPerChunk[c-1] = r.samplesPerChunk
 		}
 	}
-	for i := range samplesPerChunk {
-		if samplesPerChunk[i] == 0 {
-			samplesPerChunk[i] = runs[len(runs)-1].samplesPerChunk
+	if len(runs) > 0 {
+		for i := range samplesPerChunk {
+			if samplesPerChunk[i] == 0 {
+				samplesPerChunk[i] = runs[len(runs)-1].samplesPerChunk
+			}
 		}
 	}
 
@@ -563,26 +556,97 @@ func parseAlacTrack(data []byte, audioBody, audioEnd int) (trackData, error) {
 			break
 		}
 	}
-	return trackData{params: params, locs: locs}, nil
+	return locs, nil
 }
 
-func containsBytes(haystack, needle []byte) bool {
-	if len(needle) == 0 {
-		return true
+// findAlacTracks returns one entry per audio track whose first sample entry
+// in stsd has format == 'alac'. All other tracks (video, AAC audio, etc.)
+// are silently skipped.
+func findAlacTracks(data []byte) ([]trackData, error) {
+	if len(data) < 8 {
+		return nil, errors.New("file too small")
 	}
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		match := true
-		for j := 0; j < len(needle); j++ {
-			if haystack[i+j] != needle[j] {
-				match = false
-				break
+	moov, ok := findChild(data, 0, len(data), "moov")
+	if !ok {
+		return nil, errors.New("no moov atom (not an MP4/M4A?)")
+	}
+
+	var tracks []trackData
+	for _, trak := range findAllChildren(data, moov.bodyOff, moov.endOff, "trak") {
+		var trackID uint32
+		if tkhd, ok := findChild(data, trak.bodyOff, trak.endOff, "tkhd"); ok {
+			b := tkhd.bodyOff
+			version := data[b]
+			if version == 0 && tkhd.endOff-b >= 20 {
+				trackID = binary.BigEndian.Uint32(data[b+12 : b+16])
+			} else if version == 1 && tkhd.endOff-b >= 32 {
+				trackID = binary.BigEndian.Uint32(data[b+20 : b+24])
 			}
 		}
-		if match {
-			return true
+
+		mdia, ok := findChild(data, trak.bodyOff, trak.endOff, "mdia")
+		if !ok {
+			continue
 		}
+		// Require handler_type == 'soun'.
+		hdlr, ok := findChild(data, mdia.bodyOff, mdia.endOff, "hdlr")
+		if !ok {
+			continue
+		}
+		hb := hdlr.bodyOff
+		if hdlr.endOff-hb < 12 || string(data[hb+8:hb+12]) != "soun" {
+			continue
+		}
+		minf, ok := findChild(data, mdia.bodyOff, mdia.endOff, "minf")
+		if !ok {
+			continue
+		}
+		stbl, ok := findChild(data, minf.bodyOff, minf.endOff, "stbl")
+		if !ok {
+			continue
+		}
+		stsd, ok := findChild(data, stbl.bodyOff, stbl.endOff, "stsd")
+		if !ok {
+			continue
+		}
+		// stsd body: version+flags(4) | entry_count(4) | sample_entries...
+		b := stsd.bodyOff
+		if stsd.endOff-b < 8 {
+			continue
+		}
+		entryCount := binary.BigEndian.Uint32(data[b+4 : b+8])
+		if entryCount == 0 {
+			continue
+		}
+		entryStart := b + 8
+		if entryStart+8 > stsd.endOff {
+			continue
+		}
+		entrySize := int(binary.BigEndian.Uint32(data[entryStart : entryStart+4]))
+		entryType := string(data[entryStart+4 : entryStart+8])
+		if entrySize < 8 || entryStart+entrySize > stsd.endOff {
+			continue
+		}
+		if entryType != "alac" {
+			continue
+		}
+		sampleEntry := atom{
+			typ:     entryType,
+			hdrOff:  entryStart,
+			bodyOff: entryStart + 8,
+			endOff:  entryStart + entrySize,
+		}
+		params, err := extractAlacConfig(data, sampleEntry)
+		if err != nil {
+			return nil, fmt.Errorf("track %d: %w", trackID, err)
+		}
+		locs, err := readPacketLocations(data, stbl)
+		if err != nil {
+			return nil, fmt.Errorf("track %d: %w", trackID, err)
+		}
+		tracks = append(tracks, trackData{trackID: trackID, params: params, locs: locs})
 	}
-	return false
+	return tracks, nil
 }
 
 // ---------- Patcher ---------------------------------------------------------
@@ -592,14 +656,12 @@ func patchInPlace(data []byte, off int64, size int, bodyEndBit int) bool {
 	if bodyEndBit < 0 || bodyEndBit+3 > totalBits {
 		return false
 	}
-	// Set 3 tag bits to 1,1,1.
 	for i := 0; i < 3; i++ {
 		bp := bodyEndBit + i
 		bi := off + int64(bp>>3)
 		mask := byte(1 << uint(7-(bp&7)))
 		data[bi] |= mask
 	}
-	// Zero everything from bodyEndBit+3 to end of packet.
 	padStart := bodyEndBit + 3
 	bi := off + int64(padStart>>3)
 	bitInByte := padStart & 7
@@ -622,7 +684,7 @@ func Run(path string) error {
 	if err != nil {
 		return err
 	}
-	tracks, err := findAudioTracks(data)
+	tracks, err := findAlacTracks(data)
 	if err != nil {
 		return err
 	}
@@ -631,7 +693,7 @@ func Run(path string) error {
 	}
 
 	type bad struct {
-		trackIdx   int
+		trackID    uint32
 		idx        int
 		off        int64
 		size       int
@@ -641,10 +703,10 @@ func Run(path string) error {
 	patched := 0
 	var report []bad
 
-	for ti, td := range tracks {
+	for _, td := range tracks {
 		params := td.params
-		fmt.Printf("Track %d: %d ALAC packets, max_samples_per_frame=%d sample_size=%d channels=%d\n",
-			ti, len(td.locs), params.maxSamplesPerFrame, params.sampleSize, params.channels)
+		fmt.Printf("Track #%d: %d packets, max_samples_per_frame=%d sample_size=%d channels=%d\n",
+			td.trackID, len(td.locs), params.maxSamplesPerFrame, params.sampleSize, params.channels)
 
 		for idx, loc := range td.locs {
 			pkt := data[loc.offset : loc.offset+int64(loc.size)]
@@ -658,14 +720,13 @@ func Run(path string) error {
 			br := newBitReader(pkt)
 			_ = br.skip(bodyEnd)
 			if br.left() >= 3 {
-				tag, _ := br.show(3)
-				if tag == 7 {
+				if tag, _ := br.show(3); tag == 7 {
 					continue
 				}
 			}
 			if patchInPlace(data, loc.offset, loc.size, bodyEnd) {
 				patched++
-				report = append(report, bad{ti, idx, loc.offset, loc.size, bodyEnd})
+				report = append(report, bad{td.trackID, idx, loc.offset, loc.size, bodyEnd})
 			}
 		}
 	}
@@ -677,7 +738,7 @@ func Run(path string) error {
 		fmt.Printf("Patched %d packet(s).\n", patched)
 		for _, r := range report {
 			fmt.Printf("  track #%d packet #%d  file_offset=0x%x  size=%d  body_ends_at_bit=%d  tail_overwritten=[%d..%d)\n",
-				r.trackIdx, r.idx, r.off, r.size, r.bodyEndBit, r.bodyEndBit, r.size*8)
+				r.trackID, r.idx, r.off, r.size, r.bodyEndBit, r.bodyEndBit, r.size*8)
 		}
 	}
 	return nil

--- a/utils/structs/structs.go
+++ b/utils/structs/structs.go
@@ -52,6 +52,7 @@ type ConfigSet struct {
 	ConvertSkipLossyToLossless bool   `yaml:"convert-skip-lossy-to-lossless"`
 	ConvertCheckBadALAC        bool   `yaml:"convert-check-bad-alac"`
 	ConvertDeleteBadALAC       bool   `yaml:"convert-delete-bad-alac"`
+	ALACFix                    bool   `yaml:"alac-fix"`
 }
 
 type Counter struct {


### PR DESCRIPTION
This PR fixes corrupted ALAC files downloaded from Apple Music.

The code is AI-assisted, but it works. If it's necessary, I can make some manual changes, but the feature is disabled by default, so these changes shouldn't cause any issues.

Comparing FLAC files purchased on Bandcamp with their ALAC counterparts from Apple Music, I found that the corruption is present from the very beginning - not introduced during download or decrypting. Playing such a track in Apple Music on a MacBook with the latest macOS still produces the same minor byte-level losses. QuickTime simply ignores the malformed packets, but FFmpeg's decoder cannot. The algorithm does not make things worse; it only makes the files readable by FFmpeg.

<img width="3440" height="1407" alt="alacfix" src="https://github.com/user-attachments/assets/f4c12001-4cff-40f2-8d9b-81c58f6c781a" />

ALAC packets in the corrupted files are missing a TYPE_END terminator. The algorithm locates each such packet and appends `TYPE_END` so that FFmpeg's decoder can parse the file correctly.