### PR TITLE
Add the ability for the program to exit on error instead of requiring a human to press the enter key.

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -21,39 +21,52 @@ max-memory-limit: 256 # MB
 decrypt-m3u8-port: "127.0.0.1:10020"
 get-m3u8-port: "127.0.0.1:20020"
 get-m3u8-from-device: true
+
+# set to 'true' to exit on error instead of requiring manual intervention. (for using this program in scripts)
+exit-on-error: false
+
 #set 'all' to retrieve all m3u8, and set 'hires' to only detect hires m3u8.
 get-m3u8-mode: hires # all hires
 aac-type: aac-lc # aac-lc aac aac-binaural aac-downmix
 alac-max: 192000  #192000 96000 48000 44100
 atmos-max: 2768  #2768 2448
 limit-max: 200
+
 #{AlbumId} {AlbumName} {ArtistName} {ReleaseDate} {ReleaseYear} {UPC} {Copyright} {Quality} {Codec} {Tag} {RecordLabel}
 #example: {ReleaseYear} - {ArtistName} - {AlbumName}({AlbumId})({UPC})({Copyright}){Codec}
 album-folder-format: "{AlbumName}"
+
 #{PlaylistId} {PlaylistName} {ArtistName} {Quality} {Codec} {Tag}
 playlist-folder-format: "{PlaylistName}"
+
 #{SongId} {SongNumer} {SongName} {DiscNumber} {TrackNumber} {Quality} {Codec} {Tag}
 #example: Disk {DiscNumber} - Track {TrackNumber} {SongName} [{Quality}]{{Tag}}"
 song-file-format: "{SongNumer}. {SongName}"
+
 #{ArtistId} {ArtistName}/{UrlArtistName}
 #if artist-folder-format set "",will not make artist folder
 artist-folder-format: "{UrlArtistName}"
+
 #if set "" will not add tag
 explicit-choice : "[E]"
 clean-choice : "[C]"
 apple-master-choice : "[M]"
+
 #if set true,for playlst,will use songinfo for meta #albumname track disk
 use-songinfo-for-playlist: false
+
 #if set true,will download album cover for playlist
 dl-albumcover-for-playlist: false
 mv-audio-type: atmos  #atmos ac3 aac
 mv-max: 2160
+
 # storefront will be used only in searching. 
 # storefront is the 2-letter country code that are available in the urls (jp, ca, us etc.).
 # if your account is from Japan, you must use jp.
 # if the storefront is different from your account, you will see a "failed to get lyrics" error in most of the songs. By default the storefront is set to US if not set.
 storefront: "enter your account storefront"
 alac-fix: false                   # Patch malformed ALAC packets
+
 # Conversion settings
 convert-after-download: false     # Enable post-download conversion (requires ffmpeg)
 convert-format: "flac"            # flac | mp3 | opus | wav | copy (no re-encode)
@@ -62,6 +75,7 @@ convert-skip-if-source-matches: true  # If already in target format, skip
 ffmpeg-path: "ffmpeg"             # Override if ffmpeg is not in PATH
 convert-extra-args: ""            # Additional raw args appended (advanced)
 convert-with-metadata: true      # If true, keep the same metadata in converted files
+
 # Conversion warnings and behavior
 convert-warn-lossy-to-lossless: true # If true, print a warning when converting a detected lossy source to a lossless container
 convert-skip-lossy-to-lossless: true # If true, skip converting detected lossy sources to lossless target formats (flac/wav)

--- a/main.go
+++ b/main.go
@@ -39,24 +39,24 @@ import (
 )
 
 var (
-	forbiddenNames = regexp.MustCompile(`[/\\<>:"|?*]`)
-	dl_atmos       bool
-	dl_aac         bool
-	dl_select      bool
-	dl_song        bool
-	artist_select  bool
-	debug_mode     bool
-	print_json     bool
-	save_m3u8_playlist     bool
-	alac_max       *int
-	atmos_max      *int
-	mv_max         *int
-	mv_audio_type  *string
-	aac_type       *string
-	Config         structs.ConfigSet
-	counter        structs.Counter
-	okDict         = make(map[string][]int)
-	AddedTracks    []AddedTrack
+	forbiddenNames     = regexp.MustCompile(`[/\\<>:"|?*]`)
+	dl_atmos           bool
+	dl_aac             bool
+	dl_select          bool
+	dl_song            bool
+	artist_select      bool
+	debug_mode         bool
+	print_json         bool
+	save_m3u8_playlist bool
+	alac_max           *int
+	atmos_max          *int
+	mv_max             *int
+	mv_audio_type      *string
+	aac_type           *string
+	Config             structs.ConfigSet
+	counter            structs.Counter
+	okDict             = make(map[string][]int)
+	AddedTracks        []AddedTrack
 )
 
 type AddedTrack struct {
@@ -2112,10 +2112,15 @@ func main() {
 		fmt.Printf("=======  [\u2714 ] Completed: %d/%d  |  [\u26A0 ] Warnings: %d  |  [\u2716 ] Errors: %d  =======\n", counter.Success, counter.Total, counter.Unavailable+counter.NotSong, counter.Error)
 		if counter.Error == 0 {
 			break
+		} else if Config.ExitOnError {
+			fmt.Println("Error detected, exiting...")
+			os.Exit(1)
+		} else {
+			fmt.Println("Error detected, press Enter to try again...")
+			fmt.Scanln()
+			fmt.Println("Start trying again...")
 		}
-		fmt.Println("Error detected, press Enter to try again...")
-		fmt.Scanln()
-		fmt.Println("Start trying again...")
+
 		counter = structs.Counter{}
 	}
 

--- a/utils/structs/structs.go
+++ b/utils/structs/structs.go
@@ -53,6 +53,7 @@ type ConfigSet struct {
 	ConvertCheckBadALAC        bool   `yaml:"convert-check-bad-alac"`
 	ConvertDeleteBadALAC       bool   `yaml:"convert-delete-bad-alac"`
 	ALACFix                    bool   `yaml:"alac-fix"`
+	ExitOnError                bool   `yaml:"exit-on-error"`
 }
 
 type Counter struct {


### PR DESCRIPTION
The program is difficult to use in scripts because of the lack of an option to exit when the program detects errors.

The program currently requires a person to press the enter key to retry, or to press CTRL+C to exit. This change allows the user to choose whether they want the program to automatically exit on error or not via config option.

Depiction of before + Depiction of `exit-on-error` set to `false`: the user has to press `enter` for the program to retry, or send `^C` to the program for it to exit.
<img width="738" height="238" alt="final_bef" src="https://github.com/user-attachments/assets/6a926fb1-c599-4c0a-ae2e-167cc850323d" />

Depiction of after / `exit-on-error` set to `true` the program exits automatically when it detects an error. When it detects an error, it exits with status 1.
<img width="655" height="298" alt="final_after" src="https://github.com/user-attachments/assets/1ece90af-90e4-4591-b816-832c9e91edaa" />

`exit-on-error` is set to `false` by default, so the change will only be seen by those who want to see it.