### PR TITLE
fix: Update developer token regex

### DIFF
--- a/utils/ampapi/token.go
+++ b/utils/ampapi/token.go
@@ -42,7 +42,7 @@ func GetToken() (string, error) {
 		return "", err
 	}
 
-	regex = regexp.MustCompile(`eyJh([^"]*)`)
+	regex = regexp.MustCompile(`eyJ[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+`)
 	token := regex.FindString(string(body))
 
 	return token, nil


### PR DESCRIPTION
It didn't work for me because it couldnt' find the developer token, I found it was because the token had another format (it didn't have the h), so I modified the regex to be more broad