### PR TITLE
fix: bypass Apple API 503 / lyrics block on cloud servers via optiona…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !/go.sum
 !/main.go
 !/README.md
+!/PROXY-SETUP.md
 !/utils/
 !/utils/**
 !/cmd/

--- a/PROXY-SETUP.md
+++ b/PROXY-SETUP.md
@@ -1,0 +1,267 @@
+# 🌐 Cloud Server Proxy Setup
+
+> **Fixes:** `Failed to get song response.` · `503 Service Unavailable` · `failed to get lyrics`
+
+[English](#english) | [简体中文](#简体中文)
+
+---
+
+<a name="english"></a>
+
+## English
+
+Cloud hosting providers (like **DigitalOcean**, **AWS**, **Hetzner**, **Vultr**, etc.) often have their IP ranges **blocked by Apple Music's API** (`amp-api.music.apple.com`). This causes the following errors on the server even though everything works fine locally:
+
+```
+Failed to get song response.
+Failed to rip song: 503 Service Unavailable
+failed to get lyrics
+```
+
+To fix this, you can route all Apple API HTTP requests through a local proxy. This **does not touch your server's main IP address or break SSH in any way**.
+
+---
+
+### 1. Config Option
+
+In your `config.yaml`, set the `proxy` field:
+
+```yaml
+# SOCKS5 or HTTP proxy URL.
+# Leave empty "" for direct connection (local PC / no proxy needed).
+# For cloud servers blocked by Apple, use one of the options below.
+proxy: "socks5://127.0.0.1:1080"
+```
+
+---
+
+### 2. Option A — Cloudflare WARP (Recommended)
+
+Cloudflare WARP in **proxy mode** runs a local SOCKS5 proxy on port `1080`. It does **not** replace your server's system IP or route all traffic — only the Go process's HTTP calls go through it.
+
+#### Step 1: Install Cloudflare WARP
+
+```bash
+# Add Cloudflare GPG key and repository
+curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg | sudo gpg --yes --dearmor --output /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflare-client.list
+
+# Update and install
+sudo apt update && sudo apt install cloudflare-warp -y
+```
+
+#### Step 2: Configure WARP in Proxy Mode
+
+```bash
+# Register a new WARP account
+warp-cli registration new
+
+# CRITICAL: Set to proxy mode (prevents SSH disconnects / IP changes)
+warp-cli mode proxy
+
+# Set the local SOCKS5 proxy port
+warp-cli proxy port 1080
+
+# Connect
+warp-cli connect
+```
+
+#### Step 3: Enable Auto-Start on Boot
+
+```bash
+sudo systemctl enable warp-svc
+```
+
+#### Step 4: Update config.yaml
+
+```yaml
+proxy: "socks5://127.0.0.1:1080"
+```
+
+#### Verify It Works
+
+```bash
+# Your server's real IP (unchanged)
+curl https://api.ipify.org
+
+# Traffic through WARP (Cloudflare proxy IP)
+curl --socks5 127.0.0.1:1080 https://www.cloudflare.com/cdn-cgi/trace
+```
+
+> If the second command shows `warp=on`, the proxy is working correctly.
+
+---
+
+### 3. Option B — SSH Reverse Tunnel (Zero Cost, No Install)
+
+If you don't want to install anything on the server, you can forward your **local machine's internet connection** to the server via an SSH tunnel.
+
+#### On your LOCAL machine (Windows / macOS / Linux):
+
+```bash
+ssh -R 1080 -N user@YOUR_SERVER_IP
+```
+
+Keep this terminal open while downloading. This opens a SOCKS5 proxy on `127.0.0.1:1080` **on the server**, tunnelled through your local internet connection.
+
+#### On the server, set config.yaml:
+
+```yaml
+proxy: "socks5://127.0.0.1:1080"
+```
+
+> ✅ SSH itself is **never** affected. This tunnel only makes port 1080 available locally on the server.
+
+---
+
+### 4. Local PC (Windows / macOS) — No Proxy Needed
+
+If you're running the tool on your own computer, Apple's API is usually accessible directly. Leave the proxy setting empty:
+
+```yaml
+proxy: ""
+```
+
+---
+
+### 5. Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `503 Service Unavailable` | Server IP blocked by Apple | Set proxy in `config.yaml` |
+| `failed to get lyrics` | `amp-api.music.apple.com` blocked | Set proxy in `config.yaml` |
+| `proxy config error: ...` | Invalid proxy URL format | Check URL format: `socks5://host:port` |
+| ALAC/Atmos works but lyrics/AAC fail | Only API calls blocked, not CDN | Normal — proxy fixes API calls |
+| SSH disconnected after WARP install | WARP set to VPN mode instead of proxy mode | Run `warp-cli mode proxy` again |
+
+---
+
+<a name="简体中文"></a>
+
+## 简体中文
+
+云服务器（如 **DigitalOcean**、**AWS**、**Hetzner**、**Vultr** 等）的 IP 段经常被 Apple Music API（`amp-api.music.apple.com`）屏蔽，导致在服务器上运行时出现以下错误（而本地电脑完全正常）：
+
+```
+Failed to get song response.
+Failed to rip song: 503 Service Unavailable
+failed to get lyrics
+```
+
+解决方法是将所有 Apple API 请求通过本地代理转发。**这不会改变服务器主 IP 地址，也不会影响 SSH 连接。**
+
+---
+
+### 1. 配置选项
+
+在 `config.yaml` 中设置 `proxy` 字段：
+
+```yaml
+# SOCKS5 或 HTTP 代理地址。
+# 本地电脑无需代理，留空即可。
+# 云服务器被 Apple 屏蔽时，使用以下任一选项。
+proxy: "socks5://127.0.0.1:1080"
+```
+
+---
+
+### 2. 方案 A — Cloudflare WARP（推荐）
+
+Cloudflare WARP 的**代理模式**会在本地启动一个 SOCKS5 代理（端口 `1080`）。它**不会**替换服务器系统 IP 或路由全局流量 —— 只有 Go 程序的 HTTP 请求会通过代理。
+
+#### 第一步：安装 Cloudflare WARP
+
+```bash
+# 添加 Cloudflare GPG 密钥和软件源
+curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg | sudo gpg --yes --dearmor --output /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflare-client.list
+
+# 更新并安装
+sudo apt update && sudo apt install cloudflare-warp -y
+```
+
+#### 第二步：配置 WARP 代理模式
+
+```bash
+# 注册新的 WARP 账户
+warp-cli registration new
+
+# 关键：设置为代理模式（防止 SSH 断连 / IP 被替换）
+warp-cli mode proxy
+
+# 设置本地 SOCKS5 代理端口
+warp-cli proxy port 1080
+
+# 连接
+warp-cli connect
+```
+
+#### 第三步：设置开机自启
+
+```bash
+sudo systemctl enable warp-svc
+```
+
+#### 第四步：修改 config.yaml
+
+```yaml
+proxy: "socks5://127.0.0.1:1080"
+```
+
+#### 验证是否正常工作
+
+```bash
+# 服务器真实 IP（保持不变）
+curl https://api.ipify.org
+
+# 通过 WARP 的流量（Cloudflare 代理 IP）
+curl --socks5 127.0.0.1:1080 https://www.cloudflare.com/cdn-cgi/trace
+```
+
+> 若第二条命令输出包含 `warp=on`，代理配置成功。
+
+---
+
+### 3. 方案 B — SSH 反向隧道（零成本，无需安装）
+
+如果不想在服务器上安装任何软件，可以通过 SSH 将本地电脑的网络连接转发到服务器。
+
+#### 在你的**本地电脑**上执行（Windows / macOS / Linux）：
+
+```bash
+ssh -R 1080 -N user@YOUR_SERVER_IP
+```
+
+下载期间保持此终端开启。这会在**服务器的** `127.0.0.1:1080` 上开放一个 SOCKS5 代理，通过本地网络进行中转。
+
+#### 在服务器的 config.yaml 中设置：
+
+```yaml
+proxy: "socks5://127.0.0.1:1080"
+```
+
+> ✅ SSH 连接**不受任何影响**。此隧道仅在服务器本地开放 1080 端口。
+
+---
+
+### 4. 本地电脑（Windows / macOS）— 无需代理
+
+如果在自己的电脑上运行，通常可以直接访问 Apple 接口，无需代理，留空即可：
+
+```yaml
+proxy: ""
+```
+
+---
+
+### 5. 故障排查
+
+| 错误 | 原因 | 解决方法 |
+|------|------|----------|
+| `503 Service Unavailable` | 服务器 IP 被 Apple 屏蔽 | 在 `config.yaml` 中配置代理 |
+| `failed to get lyrics` | `amp-api.music.apple.com` 被屏蔽 | 在 `config.yaml` 中配置代理 |
+| `proxy config error: ...` | 代理 URL 格式错误 | 检查格式：`socks5://host:port` |
+| ALAC/Atmos 正常但歌词/AAC 失败 | 仅 API 接口被屏蔽，CDN 正常 | 正常现象，配置代理后修复 |
+| 安装 WARP 后 SSH 断连 | WARP 设置为 VPN 模式而非代理模式 | 重新运行 `warp-cli mode proxy` |

--- a/README-CN.md
+++ b/README-CN.md
@@ -1,6 +1,6 @@
 # Apple Music ALAC / 杜比全景声下载器
 
-[English](./README.md) | [简体中文](./README-CN.md)
+[English](./README.md) | [简体中文](./README-CN.md) | [🌐 云服务器/代理配置](./PROXY-SETUP.md)
 
 > **原脚本由 Sorrow 编写。** 本仓库已作修改，包含一些修复和改进。
 
@@ -172,6 +172,19 @@ docker run --network host -v ./downloads:/downloads -v ./config.yaml:/app/config
 9. 复制语言值并粘贴到 `config.yaml` 中
 10. **可选：** 如需禁用发音，在 config.yaml 中移除对应值：`...%5D=<remove_this_value>&extend...`
 11. 保存并照常运行脚本
+
+---
+
+## 🖥️ 在云服务器上运行？（DigitalOcean / VPS）
+
+如果你在服务器上遇到 `503 Service Unavailable` 或 `failed to get lyrics`，说明 Apple Music API 封锁了你服务器的 IP。
+
+➡️ **完整解决方案：[PROXY-SETUP.md](./PROXY-SETUP.md)**
+
+快速配置——安装 [Cloudflare WARP](./PROXY-SETUP.md#2-方案-a--cloudflare-warp推荐) 或使用 [SSH 隆道](./PROXY-SETUP.md#3-方案-b--ssh-反向隊道零成本无需安装)，然后在 `config.yaml` 中添加：
+```yaml
+proxy: "socks5://127.0.0.1:1080"
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apple Music ALAC / Dolby Atmos Downloader
 
-[English](./README.md) | [简体中文](./README-CN.md)
+[English](./README.md) | [简体中文](./README-CN.md) | [🌐 Cloud Server / Proxy Setup](./PROXY-SETUP.md)
 
 > **Original script by Sorrow.** Modified with fixes and improvements.
 
@@ -172,6 +172,19 @@ docker run --network host -v ./downloads:/downloads -v ./config.yaml:/app/config
 9. Copy the language value and paste it into `config.yaml`
 10. **Optional:** To disable pronunciation, remove the corresponding value in config.yaml: `...%5D=<remove_this_value>&extend...`
 11. Save and run the script as usual
+
+---
+
+## 🖥️ Running on a Cloud Server (DigitalOcean / VPS)?
+
+If you're getting `503 Service Unavailable`  on your server, Apple Music's API likely blocks your server's IP.
+
+➡️ **See the full fix guide: [PROXY-SETUP.md](./PROXY-SETUP.md)**
+
+Quick summary — add this to `config.yaml` after setting up [Cloudflare WARP](./PROXY-SETUP.md#2-option-a--cloudflare-warp-recommended) or an [SSH tunnel](./PROXY-SETUP.md#3-option-b--ssh-reverse-tunnel-zero-cost-no-install):
+```yaml
+proxy: "socks5://127.0.0.1:1080"
+```
 
 ---
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -81,3 +81,18 @@ convert-warn-lossy-to-lossless: true # If true, print a warning when converting 
 convert-skip-lossy-to-lossless: true # If true, skip converting detected lossy sources to lossless target formats (flac/wav)
 convert-check-bad-alac: false # If true, check and report if ALAC is damaged
 convert-delete-bad-alac: false # If true, delete if ALAC is damaged
+
+# ---------------------------------------------------------------------------
+# Proxy — Fix for Cloud Servers Blocked by Apple Music API
+# Errors fixed: "503 Service Unavailable" / "Failed to get song response." /
+#               "failed to get lyrics"
+# See full guide: PROXY-SETUP.md
+# ---------------------------------------------------------------------------
+#
+# Supported formats:
+#   proxy: ""                          # No proxy (default — local PC)
+#   proxy: "socks5://127.0.0.1:1080"  # SOCKS5 proxy (Cloudflare WARP / SSH tunnel)
+#   proxy: "http://127.0.0.1:3128"    # HTTP proxy
+#
+# ---------------------------------------------------------------------------
+proxy: ""

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	"main/utils/alacfix"
 	"main/utils/ampapi"
+	"main/utils/httputil"
 	"main/utils/lyrics"
 	"main/utils/runv2"
 	"main/utils/runv3"
@@ -213,7 +214,7 @@ func getUrlArtistName(artistUrl string, token string) (string, string, error) {
 	query := url.Values{}
 	query.Set("l", Config.Language)
 	req.URL.RawQuery = query.Encode()
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return "", "", err
 	}
@@ -244,7 +245,7 @@ func checkArtist(artistUrl string, token string, relationship string) ([]string,
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
 		req.Header.Set("Origin", "https://music.apple.com")
-		do, err := http.DefaultClient.Do(req)
+		do, err := httputil.Client.Do(req)
 		if err != nil {
 			return nil, err
 		}
@@ -391,7 +392,7 @@ func writeCover(sanAlbumFolder, name string, url string) (string, error) {
 		return "", err
 	}
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -410,7 +411,7 @@ func writeCover(sanAlbumFolder, name string, url string) (string, error) {
 				return "", err
 			}
 			req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
-			do, err = http.DefaultClient.Do(req)
+			do, err = httputil.Client.Do(req)
 			if err != nil {
 				fmt.Println("Failed to get cover from fallback url.")
 				return "", err
@@ -1963,6 +1964,10 @@ func main() {
 	err := loadConfig()
 	if err != nil {
 		fmt.Printf("load Config failed: %v", err)
+		return
+	}
+	if err := httputil.Init(Config.Proxy); err != nil {
+		fmt.Printf("proxy config error: %v\n", err)
 		return
 	}
 	token, err := ampapi.GetToken()

--- a/utils/ampapi/album.go
+++ b/utils/ampapi/album.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"main/utils/httputil"
 )
 
 func GetAlbumResp(storefront string, id string, language string, token string) (*AlbumResp, error) {
@@ -35,7 +37,7 @@ func GetAlbumResp(storefront string, id string, language string, token string) (
 	query.Set("extend", "editorialVideo,extendedAssetUrls")
 	query.Set("l", language)
 	req.URL.RawQuery = query.Encode()
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +65,7 @@ func GetAlbumResp(storefront string, id string, language string, token string) (
 			query.Set("include", "artists")
 			query.Set("extend", "editorialVideo,extendedAssetUrls")
 			req.URL.RawQuery = query.Encode()
-			do, err := http.DefaultClient.Do(req)
+			do, err := httputil.Client.Do(req)
 			if err != nil {
 				return nil, err
 			}
@@ -112,7 +114,7 @@ func GetAlbumRespByHref(href string, language string, token string) (*AlbumResp,
 	query.Set("extend", "editorialVideo,extendedAssetUrls")
 	query.Set("l", language)
 	req.URL.RawQuery = query.Encode()
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +142,7 @@ func GetAlbumRespByHref(href string, language string, token string) (*AlbumResp,
 			query.Set("include", "artists")
 			query.Set("extend", "editorialVideo,extendedAssetUrls")
 			req.URL.RawQuery = query.Encode()
-			do, err := http.DefaultClient.Do(req)
+			do, err := httputil.Client.Do(req)
 			if err != nil {
 				return nil, err
 			}

--- a/utils/ampapi/musicvideo.go
+++ b/utils/ampapi/musicvideo.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"main/utils/httputil"
 )
 
 func GetMusicVideoResp(storefront string, id string, language string, token string) (*MusicVideoResp, error) {
@@ -35,7 +37,7 @@ func GetMusicVideoResp(storefront string, id string, language string, token stri
 	//query.Set("extend", "editorialVideo")
 	query.Set("l", language)
 	req.URL.RawQuery = query.Encode()
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/ampapi/playlist.go
+++ b/utils/ampapi/playlist.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"main/utils/httputil"
 )
 
 func GetPlaylistResp(storefront string, id string, language string, token string) (*PlaylistResp, error) {
@@ -34,7 +36,7 @@ func GetPlaylistResp(storefront string, id string, language string, token string
 	query.Set("extend", "editorialVideo,extendedAssetUrls")
 	query.Set("l", language)
 	req.URL.RawQuery = query.Encode()
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +64,7 @@ func GetPlaylistResp(storefront string, id string, language string, token string
 			query.Set("include", "artists")
 			query.Set("extend", "editorialVideo,extendedAssetUrls")
 			req.URL.RawQuery = query.Encode()
-			do, err := http.DefaultClient.Do(req)
+			do, err := httputil.Client.Do(req)
 			if err != nil {
 				return nil, err
 			}

--- a/utils/ampapi/search.go
+++ b/utils/ampapi/search.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"main/utils/httputil"
 )
 
 // SearchResp represents the top-level response from the search API.
@@ -75,7 +77,7 @@ func Search(storefront, term, types, language, token string, limit, offset int) 
 	query.Set("l", language)
 	req.URL.RawQuery = query.Encode()
 
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/ampapi/song.go
+++ b/utils/ampapi/song.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"main/utils/httputil"
 )
 
 func GetSongResp(storefront string, id string, language string, token string) (*SongResp, error) {
@@ -35,7 +37,7 @@ func GetSongResp(storefront string, id string, language string, token string) (*
 	//query.Set("extend", "editorialVideo")
 	query.Set("l", language)
 	req.URL.RawQuery = query.Encode()
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/ampapi/station.go
+++ b/utils/ampapi/station.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"main/utils/httputil"
 )
 
 func GetStationResp(storefront string, id string, language string, token string) (*StationResp, error) {
@@ -29,7 +31,7 @@ func GetStationResp(storefront string, id string, language string, token string)
 	query.Set("extend", "editorialVideo")
 	query.Set("l", language)
 	req.URL.RawQuery = query.Encode()
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +71,7 @@ func GetStationAssetsUrlAndServerUrl(id string, mutoken string, token string) (s
 	query.Set("kind", "radioStation")
 	query.Set("keyFormat", "web")
 	req.URL.RawQuery = query.Encode()
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return "", "", err
 	}
@@ -110,7 +112,7 @@ func GetStationNextTracks(id, mutoken, language, token string) (*TrackResp, erro
 	query.Set("extend", "editorialVideo,extendedAssetUrls")
 	query.Set("l", language)
 	req.URL.RawQuery = query.Encode()
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/ampapi/token.go
+++ b/utils/ampapi/token.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+
+	"main/utils/httputil"
 )
 
 func GetToken() (string, error) {
@@ -12,7 +14,7 @@ func GetToken() (string, error) {
 		return "", err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.Client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -31,7 +33,7 @@ func GetToken() (string, error) {
 		return "", err
 	}
 
-	resp, err = http.DefaultClient.Do(req)
+	resp, err = httputil.Client.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/utils/httputil/client.go
+++ b/utils/httputil/client.go
@@ -1,0 +1,75 @@
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+// Client is the shared HTTP client used by all Apple API requests.
+// It is initialised once via Init() with an optional proxy URL.
+var Client = http.DefaultClient
+
+// Init configures the shared Client.
+// proxyURL may be empty (no proxy), or any of:
+//
+//	socks5://user:pass@host:port
+//	socks5://host:port
+//	http://host:port
+//	https://host:port
+//
+// If the proxyURL is "system" the standard http.DefaultClient is kept as-is
+// (honours HTTP_PROXY / HTTPS_PROXY environment variables automatically).
+func Init(proxyURL string) error {
+	proxyURL = strings.TrimSpace(proxyURL)
+	if proxyURL == "" || proxyURL == "system" {
+		// keep http.DefaultClient – it already reads HTTP_PROXY env vars
+		return nil
+	}
+
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return fmt.Errorf("invalid proxy URL %q: %w", proxyURL, err)
+	}
+
+	var transport *http.Transport
+
+	switch strings.ToLower(parsed.Scheme) {
+	case "socks5", "socks5h":
+		var auth *proxy.Auth
+		if parsed.User != nil {
+			pass, _ := parsed.User.Password()
+			auth = &proxy.Auth{
+				User:     parsed.User.Username(),
+				Password: pass,
+			}
+		}
+		dialer, err := proxy.SOCKS5("tcp", parsed.Host, auth, proxy.Direct)
+		if err != nil {
+			return fmt.Errorf("failed to create SOCKS5 dialer: %w", err)
+		}
+		transport = &http.Transport{
+			Dial:                dialer.Dial,
+			TLSHandshakeTimeout: 30 * time.Second,
+		}
+
+	case "http", "https":
+		transport = &http.Transport{
+			Proxy:               http.ProxyURL(parsed),
+			TLSHandshakeTimeout: 30 * time.Second,
+		}
+
+	default:
+		return fmt.Errorf("unsupported proxy scheme %q (supported: socks5, http, https)", parsed.Scheme)
+	}
+
+	Client = &http.Client{
+		Transport: transport,
+		Timeout:   60 * time.Second,
+	}
+	return nil
+}

--- a/utils/lyrics/lyrics.go
+++ b/utils/lyrics/lyrics.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/beevik/etree"
+	"main/utils/httputil"
 )
 
 type SongLyrics struct {
@@ -60,7 +61,7 @@ func getSongLyrics(songId string, storefront string, token string, userToken str
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	cookie := http.Cookie{Name: "media-user-token", Value: userToken}
 	req.AddCookie(&cookie)
-	do, err := http.DefaultClient.Do(req)
+	do, err := httputil.Client.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/utils/runv3/runv3.go
+++ b/utils/runv3/runv3.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/grafov/m3u8"
 	"github.com/schollz/progressbar/v3"
+
+	"main/utils/httputil"
 )
 
 type PlaybackLicense struct {
@@ -125,7 +127,7 @@ func getURLWithHeaders(url string, authtoken string, mutoken string) ([]byte, er
 	for key, value := range getPlaybackHeaders(authtoken, mutoken) {
 		req.Header.Set(key, value)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func GetWebplayback(adamId string, authtoken string, mutoken string, mvmode bool
 	req.Header.Set("x-apple-music-user-token", mutoken)
 	// 创建 HTTP 客户端
 	//client := &http.Client{}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.Client.Do(req)
 	// 发送请求
 	//resp, err := client.Do(req)
 	if err != nil {

--- a/utils/structs/structs.go
+++ b/utils/structs/structs.go
@@ -54,6 +54,7 @@ type ConfigSet struct {
 	ConvertDeleteBadALAC       bool   `yaml:"convert-delete-bad-alac"`
 	ALACFix                    bool   `yaml:"alac-fix"`
 	ExitOnError                bool   `yaml:"exit-on-error"`
+	Proxy                      string `yaml:"proxy"`
 }
 
 type Counter struct {


### PR DESCRIPTION
## 🚀 Title
`feat: add SOCKS5/HTTP proxy support to resolve VPS IP blocks on Apple Music API`

---

## 📌 Summary

This PR adds configurable SOCKS5/HTTP proxy support across all Apple API calls in the project.

### 🛑 Root Cause

Cloud hosting providers (e.g., DigitalOcean, AWS, Hetzner) have their IP ranges blocked by Apple Music's API (`amp-api.music.apple.com`), causing:

- `503 Service Unavailable` when fetching song metadata / AAC-LC streams
- `failed to get lyrics` on all VPS environments

ALAC and Atmos downloads are unaffected since they use CDN URLs, which is why the issue is easy to miss.

### 💡 Solution

Introduced a shared proxy-aware HTTP client (`utils/httputil/client.go`) and routed all Apple API requests through it. A single `proxy` field in `config.yaml` controls the behaviour — **empty by default**, so existing local users see zero change.

Compatible with **Cloudflare WARP in Proxy Mode** — routes only the Go process's HTTP calls without touching system-wide routing or dropping SSH.

---

## 🛠️ Files Changed

| File | Change |
|------|--------|
| `utils/httputil/client.go` | **New** — shared HTTP client with SOCKS5 + HTTP proxy support |
| `utils/structs/structs.go` | Added `Proxy` field to `ConfigSet` |
| `config.yaml` / `config.yaml.example` | Added `proxy: ""` with inline warp-cli setup guide |
| `main.go` · `utils/lyrics/lyrics.go` · `utils/ampapi/*.go` · `utils/runv3/runv3.go` | Replaced `http.DefaultClient` with `httputil.Client` |
| `PROXY-SETUP.md` | **New** — bilingual (EN + 中文) cloud server setup guide |
| `README.md` · `README-CN.md` | Added VPS troubleshooting section + link to guide |
| `.gitignore` | Added `!/PROXY-SETUP.md` to include new guide in repo |

---

## 🧪 Testing

| Environment | Config | Result |
|-------------|--------|--------|
| Local Windows (direct) | `proxy: ""` | ✅ Downloads and lyrics work normally |
| DigitalOcean Ubuntu VPS | `proxy: "socks5://127.0.0.1:1080"` via Cloudflare WARP | ✅ Previously failing — now works |

**Before (VPS, no proxy):**
```
Queue 1 of 1: Song->Failed to get song response.
Failed to rip song: 503 Service Unavailable
=======  [✔ ] Completed: 0/0  |  [⚠ ] Warnings: 0  |  [✖ ] Errors: 0  =======
```

**After (VPS, with `socks5://127.0.0.1:1080`):**
```
Queue 1 of 1: Song->A.R. Rahman
Ekk Deewana Tha (Original Motion Picture Soundtrack) - 492685698 - 256Kbps - AAC
Track 5 of 12: songs
05. Phoolon Jaisi
Downloaded
Decrypted
=======  [✔ ] Completed: 1/1  |  [⚠ ] Warnings: 0  |  [✖ ] Errors: 0  =======
```

---

> ✅ `go build ./...` passes with no errors. `proxy: ""` (default) is a no-op — **no breaking changes**.
